### PR TITLE
getpwuid(getuid()) it's more stable than getlogin().

### DIFF
--- a/rogueutil.h
+++ b/rogueutil.h
@@ -76,6 +76,7 @@
 	#include <sys/ioctl.h> /* for getkey() */
 	#include <sys/types.h> /* for kbhit() */
 	#include <sys/time.h> /* for kbhit() */
+	#include <pwd.h> /* for getpwduid(), getuid() */
 #endif
 
 /* Functions covered by Window's conio.h */
@@ -876,7 +877,16 @@ getUsername(void)
                 return ret;
         return NULL;
 #else /* _WIN32 */
-        return getlogin();
+#ifdef __linux__
+        struct passwd *pw = getpwuid(getuid());
+				if (pw) {
+					return pw->pw_name;
+				} else {
+					return NULL;
+				}
+#else
+				return getlogin():
+#endif
 #endif
 }
 

--- a/rogueutil.h
+++ b/rogueutil.h
@@ -71,12 +71,12 @@
 	#define kbhit _kbhit
 #else
 	#include <termios.h> /* for getch() and kbhit() */
-	#include <unistd.h> /* for getch() and kbhit() */
+	#include <unistd.h> /* for getch(), kbhit() and getuid() */
 	#include <time.h>   /* for nanosleep() */
 	#include <sys/ioctl.h> /* for getkey() */
 	#include <sys/types.h> /* for kbhit() */
 	#include <sys/time.h> /* for kbhit() */
-	#include <pwd.h> /* for getpwduid(), getuid() */
+	#include <pwd.h> /* for getpwuid() */
 #endif
 
 /* Functions covered by Window's conio.h */
@@ -876,17 +876,13 @@ getUsername(void)
         if (GetUserNameA(ret, &len))
                 return ret;
         return NULL;
-#else /* _WIN32 */
-#ifdef __linux__
-        struct passwd *pw = getpwuid(getuid());
-				if (pw) {
-					return pw->pw_name;
-				} else {
-					return NULL;
-				}
-#else
-				return getlogin():
-#endif
+#else /* _WIN32 */	
+	struct passwd *pw = getpwuid(getuid());
+	if (pw) {
+		return pw->pw_name;
+	} else {
+		return NULL;
+	}
 #endif
 }
 


### PR DESCRIPTION
Linux man page of getlogin() recommend getpwuid(getuid()) instead. It's more stable and secure.

In my case getlogin result in `segmention fault (core dumped).`