### PR TITLE
Made colorPrint (C++ version) work properly

### DIFF
--- a/rogueutil.h
+++ b/rogueutil.h
@@ -841,7 +841,7 @@ colorPrint(color_code color, color_code bgcolor, T arg, F... fmt)
 		setBackgroundColor(bgcolor);
 
 	std::cout << arg << " "; /* Let me know if I should remove the space */
-	colorPrint(color, fmt...);
+	colorPrint(color, bgcolor, fmt...);
 }
 #else
 void


### PR DESCRIPTION
Since bgcolor was missing in the function call, it was calling the wrong function (and raising compile errors)
It is a one line change but figured it could be of use to other people using the library.